### PR TITLE
Inconsistent with RUST code

### DIFF
--- a/bin/node/cli/res/custom_types.json
+++ b/bin/node/cli/res/custom_types.json
@@ -3,7 +3,7 @@
         "Parameters": {
             "canBeNominated": "bool",
             "optionExpired": "u128",
-            "optionP": "u128"
+            "optionP": "u32"
         },
         "BTreeSet": {}
     }


### PR DESCRIPTION
Inconsistent with RUST code. In my opinion the customer type should be corrected in this json file.
https://github.com/staketechnologies/Plasm/blob/8d242ed06c02ee86ba94eb947783f7b40b4b023f/frame/plasm-staking/src/parameters.rs#L20

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./.github/CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] all tests passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] \(option\)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)
<!-- Please provide affected other system(s). -->

## Description of change
<!-- Please provide a description of the change here. -->

* * *
