### PR TITLE
New CI image

### DIFF
--- a/third-party/docker/plasm_builder/Dockerfile
+++ b/third-party/docker/plasm_builder/Dockerfile
@@ -1,5 +1,5 @@
 # Use parity rust-builder as our base image.
-FROM parity/rust-builder
+FROM paritytech/ci-linux:production
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Please consider changing the source image as `parity/rust-builder` is going to be deprecated.