### PR TITLE
increase initial balance for testnet

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -1,6 +1,7 @@
 //! Chain specification.
 
 use plasm_primitives::{AccountId, Balance, Signature};
+use plasm_runtime::constants::currency::PLM;
 use plasm_runtime::Block;
 use plasm_runtime::{
     BabeConfig, BalancesConfig, ContractsConfig, GenesisConfig, GrandpaConfig, IndicesConfig,
@@ -93,7 +94,7 @@ fn testnet_genesis(
     endowed_accounts: Option<Vec<AccountId>>,
     sudo_key: AccountId,
 ) -> GenesisConfig {
-    const ENDOWMENT: Balance = 1_000_000_000_000_000_000;
+    const ENDOWMENT: Balance = 1_000_000_000 * PLM;
 
     let endowed_accounts: Vec<(AccountId, Balance)> = endowed_accounts
         .unwrap_or_else(|| {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./.github/CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] all tests passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] \(option\)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)
<!-- Please provide affected other system(s). -->

## Description of change
<!-- Please provide a description of the change here. -->
When I run development mode by `plasm-node --dev`, only 1000 Unit is issued to development accounts. However, initializing contract requires more than 1000 Unit, and this is very inconvenient for developers.
So, I've increased the initial balance for testnet genesis to 1 Giga Units.
* * *
