### PR TITLE
Register introducer's frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-register-introrucers"
+version = "1.6.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "hex-literal 0.2.1",
+ "num-traits",
+ "pallet-balances",
+ "pallet-randomness-collective-flip",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-session"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "frame/plasma",
     "frame/plasma/rpc/runtime-api",
     "frame/custom-signatures",
+    "frame/register-introducers",
     "ovmi/lib",
     "ovmi/cli",
 ]

--- a/frame/register-introducers/Cargo.toml
+++ b/frame/register-introducers/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pallet-register-introrucers"
+version = "1.6.0"
+authors = ["Stake Technologies <devops@stake.co.jp>"]
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://docs.plasmnet.io/"
+repository = "https://github.com/staketechnologies/Plasm/"
+description = "FRAME pallet to manage rewards for plasm network"
+
+[dependencies]
+serde = { version = "1.0.106", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.5", features = ["derive"], default-features = false }
+num-traits = { version = "0.2", default-features = false }
+sp-runtime = { version = "2.0.0", default_features = false }
+sp-arithmetic = { version = "2.0.0", default_features = false }
+sp-io = { version = "2.0.0", default_features = false }
+sp-std = { version = "2.0.0", default_features = false }
+frame-support = { version = "2.0.0", default_features = false }
+frame-system = { version = "2.0.0", default_features = false }
+
+[dev-dependencies]
+hex-literal = "0.2.1"
+sp-core = "2.0.0"
+pallet-balances = "2.0.0"
+pallet-timestamp = "2.0.0"
+pallet-randomness-collective-flip = "2.0.0"
+
+[features]
+default = ["std"]
+std = [
+    "serde",
+    "codec/std",
+    "num-traits/std",
+    "sp-runtime/std",
+    "sp-arithmetic/std",
+    "sp-io/std",
+    "sp-std/std",
+    "frame-support/std",
+    "frame-system/std",
+]

--- a/frame/register-introducers/src/lib.rs
+++ b/frame/register-introducers/src/lib.rs
@@ -28,6 +28,11 @@ use sp_std::prelude::*;
 pub mod traits;
 pub use traits::*;
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 pub trait Trait: system::Trait {
     /// Time used for computing era duration.
     type Time: Time<Moment = Self::Moment>;
@@ -51,7 +56,7 @@ pub trait Trait: system::Trait {
 }
 
 decl_storage! {
-    trait Store for Module<T: Trait> as DappsStaking {
+    trait Store for Module<T: Trait> as RegisterIntroducers {
         /// This is the compensation paid for the dapps operator of the Plasm Network.
         /// This is stored on a per-era basis.
         pub RegisteredIntroducers get(fn registered_introducers): map hasher(twox_64_concat) T::AccountId => Option<()>;

--- a/frame/register-introducers/src/lib.rs
+++ b/frame/register-introducers/src/lib.rs
@@ -59,7 +59,7 @@ decl_storage! {
     trait Store for Module<T: Trait> as RegisterIntroducers {
         /// This is the compensation paid for the dapps operator of the Plasm Network.
         /// This is stored on a per-era basis.
-        pub RegisteredIntroducers get(fn registered_introducers): map hasher(twox_64_concat) T::AccountId => Option<()>;
+        pub RegisteredIntroducers get(fn registered_introducers): map hasher(blake2_128_concat) T::AccountId => Option<()>;
     }
 }
 

--- a/frame/register-introducers/src/lib.rs
+++ b/frame/register-introducers/src/lib.rs
@@ -1,0 +1,97 @@
+//! # Register introducer Module
+//!
+//! The register introducers module provides functionality for handling whole rewards and era.
+//!
+//! - [`register_introducers::Trait`](./trait.Trait.html)
+//! - [`Call`](./enum.Call.html)
+//! - [`Module`](./struct.Module.html)
+//!
+//! ## Overview
+//!
+//! In other words, any current PLM holder can be an introducer.
+//! This should not be a problem, as at the moment it is basically
+//! only a Lockdrop participant. There will be a registration period of
+//! about a month after the mainnet relaunch.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use frame_support::{
+    decl_error, decl_event, decl_module, decl_storage, traits::Time, weights::Weight, StorageMap,
+    StorageValue,
+};
+use frame_system::{self as system, ensure_signed};
+use sp_runtime::{
+    traits::{SaturatedConversion, Zero},
+    Perbill, RuntimeDebug,
+};
+use sp_std::{prelude::*, vec::Vec};
+
+pub mod traits;
+pub use traits::*;
+pub type MomentOf<T> = <<T as Trait>::Time as Time>::Moment;
+
+pub trait Trait: system::Trait {
+    /// Time used for computing era duration.
+    type Time: Time;
+
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+}
+
+decl_storage! {
+    trait Store for Module<T: Trait> as DappsStaking {
+
+        /// This is the end time of register
+        pub EndTimeOfRegist get(fn end_time_of_regist): MomentOf<T>;
+
+        /// This is the compensation paid for the dapps operator of the Plasm Network.
+        /// This is stored on a per-era basis.
+        pub RegisteredIntroducers get(fn registered_introducers): map hasher(twox_64_concat) T::AccountId => Option<()>;
+    }
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        AccountId = <T as system::Trait>::AccountId,
+    {
+        /// The whole reward issued in that Era.
+        /// (era_index: EraIndex, reward: Balance)
+        Registered(AccountId),
+    }
+);
+
+decl_error! {
+    /// Error for the staking module.
+    pub enum Error for Module<T: Trait> {
+        /// Duplicate accountId.
+        DuplicateAccountId,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+
+        fn deposit_event() = default;
+
+        /// Register sender id
+        /// TODO: weight
+        #[weight = 100_000]
+        pub fn register(origin) {
+            let origin = ensure_signed(origin)?;
+            // TODO: timestamp check
+            <RegisteredIntroducers<T>>::insert(&origin, ());
+            Self::deposit_event(RawEvent::Registered(origin));
+        }
+    }
+}
+
+impl<T: Trait> RegisteredIntroducersChecker<T::AccountId> for Module<T> {
+    fn is_registered(account_id: &T::AccountId) -> bool {
+        if let Some(_) = Self::registered_introducers(account_id) {
+            return true;
+        }
+        false
+    }
+}

--- a/frame/register-introducers/src/mock.rs
+++ b/frame/register-introducers/src/mock.rs
@@ -1,0 +1,97 @@
+//! Test mockup for register-introducers module.
+
+#![cfg(test)]
+
+use super::*;
+
+use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types, weights::Weight};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
+
+pub type AccountId = u64;
+pub type Moment = u64;
+
+impl_outer_origin! {
+    pub enum Origin for Test {}
+}
+
+impl_outer_dispatch! {
+    pub enum Call for Test where origin: Origin {
+        pallet_reguster_introducers::RegisterIntroducers,
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Test;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Trait for Test {
+    type Origin = Origin;
+    type BaseCallFilter = ();
+    type Index = u64;
+    type BlockNumber = u64;
+    type Call = Call;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type PalletInfo = ();
+    type AccountData = pallet_balances::AccountData<()>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = ();
+    type SystemWeightInfo = ();
+}
+
+parameter_types! {
+    pub const MinimumPeriod: Moment = 1;
+}
+
+impl pallet_timestamp::Trait for Test {
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const EndTimeOfRegistering: Moment = 100;
+}
+
+impl Trait for Test {
+    type Time = Timestamp;
+    type EndTimeOfRegistering = EndTimeOfRegistering;
+    type Moment = Moment;
+    type Event = ();
+}
+
+pub type Timestamp = pallet_timestamp::Module<Test>;
+pub type RegisterIntroducers = Module<Test>;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let storage = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    storage.into()
+}

--- a/frame/register-introducers/src/tests.rs
+++ b/frame/register-introducers/src/tests.rs
@@ -1,4 +1,4 @@
-//! Tests for the plasm-lockdrop module.
+//! Tests for the register-introrucers module.
 
 #![cfg(test)]
 
@@ -49,7 +49,7 @@ fn boundary_test() {
         assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
         assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
 
-        // Added ACCOUNT_01
+        // Added ACCOUNT_02,04
         assert_ok!(RegisterIntroducers::register(Origin::signed(ACCOUNT_02)));
         assert_ok!(RegisterIntroducers::register(Origin::signed(ACCOUNT_04)));
         assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
@@ -69,7 +69,7 @@ fn over_test() {
         assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
         assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
 
-        // Added ACCOUNT_01
+        // Failed add ACCOUNT_01,02,03,04
         assert_err!(
             RegisterIntroducers::register(Origin::signed(ACCOUNT_01)),
             Error::<Test>::Expired

--- a/frame/register-introducers/src/tests.rs
+++ b/frame/register-introducers/src/tests.rs
@@ -1,0 +1,94 @@
+//! Tests for the plasm-lockdrop module.
+
+#![cfg(test)]
+
+use super::*;
+use crate::mock::*;
+
+use frame_support::{assert_err, assert_ok};
+
+pub const ACCOUNT_01: AccountId = 1;
+pub const ACCOUNT_02: AccountId = 2;
+pub const ACCOUNT_03: AccountId = 3;
+pub const ACCOUNT_04: AccountId = 4;
+
+fn assert_timestamp(expected: Moment) {
+    assert_eq!(Timestamp::now(), expected);
+}
+
+fn set_timestamp(time: Moment) {
+    Timestamp::set_timestamp(time);
+}
+
+#[test]
+fn normal_test() {
+    new_test_ext().execute_with(|| {
+        set_timestamp(50);
+        assert_timestamp(50);
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
+
+        // Added ACCOUNT_01
+        assert_ok!(RegisterIntroducers::register(Origin::signed(ACCOUNT_01)));
+        assert!(RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
+    });
+}
+
+#[test]
+fn boundary_test() {
+    new_test_ext().execute_with(|| {
+        set_timestamp(100);
+        assert_timestamp(100);
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
+
+        // Added ACCOUNT_01
+        assert_ok!(RegisterIntroducers::register(Origin::signed(ACCOUNT_02)));
+        assert_ok!(RegisterIntroducers::register(Origin::signed(ACCOUNT_04)));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(RegisterIntroducers::is_registered(&ACCOUNT_04));
+    });
+}
+
+#[test]
+fn over_test() {
+    new_test_ext().execute_with(|| {
+        set_timestamp(101);
+        assert_timestamp(101);
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
+
+        // Added ACCOUNT_01
+        assert_err!(
+            RegisterIntroducers::register(Origin::signed(ACCOUNT_01)),
+            Error::<Test>::Expired
+        );
+        assert_err!(
+            RegisterIntroducers::register(Origin::signed(ACCOUNT_02)),
+            Error::<Test>::Expired
+        );
+        assert_err!(
+            RegisterIntroducers::register(Origin::signed(ACCOUNT_03)),
+            Error::<Test>::Expired
+        );
+        assert_err!(
+            RegisterIntroducers::register(Origin::signed(ACCOUNT_04)),
+            Error::<Test>::Expired
+        );
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_01));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_02));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_03));
+        assert!(!RegisterIntroducers::is_registered(&ACCOUNT_04));
+    });
+}

--- a/frame/register-introducers/src/traits.rs
+++ b/frame/register-introducers/src/traits.rs
@@ -1,0 +1,3 @@
+pub trait RegisteredIntroducersChecker<AccountId> {
+    fn is_registered(account_id: &AccountId) -> bool;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./.github/CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->
- Create a frame for registering the introducer.
- Thereby, the granting of 3rd Lockdrop affiliate bonuses should be automated.
- It also allows Plasm to activate Tx.
- In other words, any current PLM holder can be an introducer. This should not be a problem, as at the moment it is basically only a Lockdrop participant. There will be a registration period of about a month after the mainnet relaunch.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] all tests passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] \(option\)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)
<!-- Please provide affected other system(s). -->

## Description of change
<!-- Please provide a description of the change here. -->

* * *
